### PR TITLE
Fix last chunk issue

### DIFF
--- a/greenglacier.py
+++ b/greenglacier.py
@@ -129,7 +129,7 @@ class MultipartPartUploader(gevent.Greenlet):
         filename, offset, size = self.work
         print('uploading chunk %s' % offset)
         chunk = self.readfile(filename, offset, size)
-        return self.upload_part(chunk, offset, size)
+        return self.upload_part(chunk, offset, len(chunk))
 
     def readfile(self, filename, offset, size):
         with open(filename, 'rb') as fileobj:


### PR DESCRIPTION
If the actual chunk is smaller than the chunk size, it currently fails with an exception like:
An error occurred (InvalidParameterValueException) when calling the UploadMultipartPart operation: Content-Range: bytes 0-4194303/* is incompatible with Content-Length: 17